### PR TITLE
Update home page to use dashboard layout

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,49 +1,40 @@
 "use client"
+import React from "react"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
+import { AppSidebar } from "@/components/app-sidebar"
+import { SiteHeader } from "@/components/site-header"
+import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar"
+import { SectionCards } from "@/components/section-cards"
+import { ChartAreaInteractive } from "@/components/chart-area-interactive"
 
 export default function HomePage() {
   return (
-    <div className="min-h-screen flex flex-col bg-gray-50">
-      {/* Navbar */}
-      <header className="bg-white shadow-sm">
-        <div className="container mx-auto px-4 py-4 flex items-center justify-between">
-          <h1 className="text-2xl font-bold">JEF Poultry</h1>
-          <nav className="space-x-4">
-            <Link href="/growers" className="text-blue-600 hover:underline">
-              Growers
-            </Link>
-            <Link href="/about" className="text-gray-600 hover:underline">
-              About
-            </Link>
-            <Link href="/contact" className="text-gray-600 hover:underline">
-              Contact
-            </Link>
-          </nav>
+    <SidebarProvider
+      style={{
+        "--sidebar-width": "calc(var(--spacing) * 72)",
+        "--header-height": "calc(var(--spacing) * 12)",
+      } as React.CSSProperties}
+    >
+      <AppSidebar variant="inset" />
+      <SidebarInset>
+        <SiteHeader />
+        <div className="p-4 space-y-6">
+          <div className="text-center max-w-xl mx-auto py-10">
+            <h2 className="text-4xl font-extrabold mb-4">
+              Welcome to JEF Poultry Dashboard
+            </h2>
+            <p className="text-lg mb-6">
+              Manage your flocks, track batches, and streamline operations all from one place.
+            </p>
+            <Button asChild className="bg-blue-600 text-white hover:bg-blue-700">
+              <Link href="/growers">Go to Growers</Link>
+            </Button>
+          </div>
+          <SectionCards />
+          <ChartAreaInteractive />
         </div>
-      </header>
-
-      {/* Hero Section */}
-      <main className="flex-grow flex flex-col items-center justify-center px-4">
-        <div className="text-center max-w-xl">
-          <h2 className="text-4xl font-extrabold mb-4">
-            Welcome to JEF Poultry Dashboard
-          </h2>
-          <p className="text-lg mb-6">
-            Manage your flocks, track batches, and streamline operations all from one place.
-          </p>
-          <Button asChild className="bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700">
-            <Link href="/growers">Go to Growers</Link>
-          </Button>
-        </div>
-      </main>
-
-      {/* Footer */}
-      <footer className="bg-white border-t">
-        <div className="container mx-auto px-4 py-6 text-center text-sm text-gray-500">
-          © 2025 JEF Poultry. All rights reserved.
-        </div>
-      </footer>
-    </div>
+      </SidebarInset>
+    </SidebarProvider>
   )
 }


### PR DESCRIPTION
## Summary
- integrate sidebar and header on the landing page
- show overview cards and chart on the homepage

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843346423e08329923ba9285a33a285